### PR TITLE
2.x: Single.subscribe(BiConsumer) consistent isDisposed (#5277)

### DIFF
--- a/src/main/java/io/reactivex/internal/observers/BiConsumerSingleObserver.java
+++ b/src/main/java/io/reactivex/internal/observers/BiConsumerSingleObserver.java
@@ -37,6 +37,7 @@ implements SingleObserver<T>, Disposable {
     @Override
     public void onError(Throwable e) {
         try {
+            lazySet(DisposableHelper.DISPOSED);
             onCallback.accept(null, e);
         } catch (Throwable ex) {
             Exceptions.throwIfFatal(ex);
@@ -52,6 +53,7 @@ implements SingleObserver<T>, Disposable {
     @Override
     public void onSuccess(T value) {
         try {
+            lazySet(DisposableHelper.DISPOSED);
             onCallback.accept(value, null);
         } catch (Throwable ex) {
             Exceptions.throwIfFatal(ex);

--- a/src/test/java/io/reactivex/single/SingleSubscribeTest.java
+++ b/src/test/java/io/reactivex/single/SingleSubscribeTest.java
@@ -15,6 +15,7 @@ package io.reactivex.single;
 
 import static org.junit.Assert.*;
 
+import java.io.IOException;
 import java.util.List;
 
 import org.junit.Test;
@@ -226,5 +227,41 @@ public class SingleSubscribeTest {
     @Test
     public void errorIsDisposed() {
         assertTrue(Single.error(new TestException()).subscribe(Functions.emptyConsumer(), Functions.emptyConsumer()).isDisposed());
+    }
+
+    @Test
+    public void biConsumerIsDisposedOnSuccess() {
+        final Object[] result = { null, null };
+        
+        Disposable d = Single.just(1)
+        .subscribe(new BiConsumer<Integer, Throwable>() {
+            @Override
+            public void accept(Integer t1, Throwable t2) throws Exception {
+                result[0] = t1;
+                result[1] = t2;
+            }
+        });
+        
+        assertTrue("Not disposed?!", d.isDisposed());
+        assertEquals(1, result[0]);
+        assertNull(result[1]);
+    }
+
+    @Test
+    public void biConsumerIsDisposedOnError() {
+        final Object[] result = { null, null };
+        
+        Disposable d = Single.<Integer>error(new IOException())
+        .subscribe(new BiConsumer<Integer, Throwable>() {
+            @Override
+            public void accept(Integer t1, Throwable t2) throws Exception {
+                result[0] = t1;
+                result[1] = t2;
+            }
+        });
+        
+        assertTrue("Not disposed?!", d.isDisposed());
+        assertNull(result[0]);
+        assertTrue("" + result[1], result[1] instanceof IOException);
     }
 }


### PR DESCRIPTION
Thank you for contributing to RxJava. Before pressing the "Create Pull Request" button, please consider the following points:

  - [ ] Please give a description about what and why you are contributing, even if it's trivial.

  - [ ] Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those.

  - [ ] Please include a reasonable set of unit tests if you contribute new code or change an existing one. If you contribute an operator, (if applicable) please make sure you have tests for working with an `empty`, `just`, `range` of values as well as an `error` source, with and/or without backpressure and see if unsubscription/cancellation propagates correctly.
