### PR TITLE
Add assertValueAt(int, value) to TestObserver (#5529)

### DIFF
--- a/src/main/java/io/reactivex/observers/BaseTestConsumer.java
+++ b/src/main/java/io/reactivex/observers/BaseTestConsumer.java
@@ -17,6 +17,7 @@ import java.util.*;
 import java.util.concurrent.*;
 
 import io.reactivex.Notification;
+import io.reactivex.annotations.Experimental;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.CompositeException;
 import io.reactivex.functions.Predicate;
@@ -335,7 +336,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
 
     /**
      * Assert that this TestObserver/TestSubscriber did not receive an onNext value which is equal to
-     * the given value with respect to Objects.equals.
+     * the given value with respect to null-safe Object.equals.
      *
      * <p>History: 2.0.5 - experimental
      * @param value the value to expect not being received
@@ -397,6 +398,33 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
             } catch (Exception ex) {
                 throw ExceptionHelper.wrapOrThrow(ex);
             }
+        }
+        return (U)this;
+    }
+
+    /**
+     * Asserts that this TestObserver/TestSubscriber received an onNext value at the given index
+     * which is equal to the given value with respect to null-safe Object.equals.
+     * @param index the position to assert on
+     * @param value the value to expect
+     * @return this
+     * @since 2.1.3 - experimental
+     */
+    @SuppressWarnings("unchecked")
+    @Experimental
+    public final U assertValueAt(int index, T value) {
+        int s = values.size();
+        if (s == 0) {
+            throw fail("No values");
+        }
+
+        if (index >= s) {
+            throw fail("Invalid index: " + index);
+        }
+
+        T v = values.get(index);
+        if (!ObjectHelper.equals(value, v)) {
+            throw fail("Expected: " + valueAndClass(value) + ", Actual: " + valueAndClass(v));
         }
         return (U)this;
     }

--- a/src/test/java/io/reactivex/observers/TestObserverTest.java
+++ b/src/test/java/io/reactivex/observers/TestObserverTest.java
@@ -1383,6 +1383,48 @@ public class TestObserverTest {
     }
 
     @Test
+    public void assertValueAtIndexEmpty() {
+        TestObserver<Object> ts = new TestObserver<Object>();
+
+        Observable.empty().subscribe(ts);
+
+        thrown.expect(AssertionError.class);
+        thrown.expectMessage("No values");
+        ts.assertValueAt(0, "a");
+    }
+
+    @Test
+    public void assertValueAtIndexMatch() {
+        TestObserver<String> ts = new TestObserver<String>();
+
+        Observable.just("a", "b").subscribe(ts);
+
+        ts.assertValueAt(1, "b");
+    }
+
+    @Test
+    public void assertValueAtIndexNoMatch() {
+        TestObserver<String> ts = new TestObserver<String>();
+
+        Observable.just("a", "b", "c").subscribe(ts);
+
+        thrown.expect(AssertionError.class);
+        thrown.expectMessage("Expected: b (class: String), Actual: c (class: String) (latch = 0, values = 3, errors = 0, completions = 1)");
+        ts.assertValueAt(2, "b");
+    }
+
+    @Test
+    public void assertValueAtIndexInvalidIndex() {
+        TestObserver<String> ts = new TestObserver<String>();
+
+        Observable.just("a", "b").subscribe(ts);
+
+        thrown.expect(AssertionError.class);
+        thrown.expectMessage("Invalid index: 2 (latch = 0, values = 2, errors = 0, completions = 1)");
+        ts.assertValueAt(2, "c");
+    }
+
+    @Test
     public void withTag() {
         try {
             for (int i = 1; i < 3; i++) {


### PR DESCRIPTION
* Add assertValueAt(int, value) to TestObserver

* Fix test to call correct method

* David's comments

* Artem's comments

* 2.x: Try fixing Travis CI lack of java (#5531)

* 2.x: Try fixing Travis CI lack of java

* Force dist: precise

* Oracle JDK 8 is then

Thank you for contributing to RxJava. Before pressing the "Create Pull Request" button, please consider the following points:

  - [ ] Please give a description about what and why you are contributing, even if it's trivial.

  - [ ] Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those.

  - [ ] Please include a reasonable set of unit tests if you contribute new code or change an existing one. If you contribute an operator, (if applicable) please make sure you have tests for working with an `empty`, `just`, `range` of values as well as an `error` source, with and/or without backpressure and see if unsubscription/cancellation propagates correctly.
