### PR TITLE
2.x: Fix flaky MaybeFromCallableTest.noErrorLoss (#5541)

### DIFF
--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromActionTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromActionTest.java
@@ -135,15 +135,13 @@ public class MaybeFromActionTest {
                 @Override
                 public void run() throws Exception {
                     cdl1.countDown();
-                    cdl2.await();
+                    cdl2.await(5, TimeUnit.SECONDS);
                 }
             }).subscribeOn(Schedulers.single()).test();
 
             assertTrue(cdl1.await(5, TimeUnit.SECONDS));
 
             to.cancel();
-
-            cdl2.countDown();
 
             int timeout = 10;
 

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromCallableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromCallableTest.java
@@ -138,7 +138,7 @@ public class MaybeFromCallableTest {
                 @Override
                 public Integer call() throws Exception {
                     cdl1.countDown();
-                    cdl2.await();
+                    cdl2.await(5, TimeUnit.SECONDS);
                     return 1;
                 }
             }).subscribeOn(Schedulers.single()).test();
@@ -146,8 +146,6 @@ public class MaybeFromCallableTest {
             assertTrue(cdl1.await(5, TimeUnit.SECONDS));
 
             to.cancel();
-
-            cdl2.countDown();
 
             int timeout = 10;
 

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromRunnableTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeFromRunnableTest.java
@@ -134,7 +134,7 @@ public class MaybeFromRunnableTest {
                 public void run() {
                     cdl1.countDown();
                     try {
-                        cdl2.await();
+                        cdl2.await(5, TimeUnit.SECONDS);
                     } catch (InterruptedException ex) {
                         throw new RuntimeException(ex);
                     }
@@ -144,8 +144,6 @@ public class MaybeFromRunnableTest {
             assertTrue(cdl1.await(5, TimeUnit.SECONDS));
 
             to.cancel();
-
-            cdl2.countDown();
 
             int timeout = 10;
 


### PR DESCRIPTION
* 2.x: Fix flaky MaybeFromCallableTest.noErrorLoss

* Fix the same error in 2 other Maybe tests.

Thank you for contributing to RxJava. Before pressing the "Create Pull Request" button, please consider the following points:

  - [ ] Please give a description about what and why you are contributing, even if it's trivial.

  - [ ] Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those.

  - [ ] Please include a reasonable set of unit tests if you contribute new code or change an existing one. If you contribute an operator, (if applicable) please make sure you have tests for working with an `empty`, `just`, `range` of values as well as an `error` source, with and/or without backpressure and see if unsubscription/cancellation propagates correctly.
