### PR TITLE
2.x: Add assertValuesOnly to BaseTestConsumer. (#5568)

### DIFF
--- a/src/main/java/io/reactivex/observers/BaseTestConsumer.java
+++ b/src/main/java/io/reactivex/observers/BaseTestConsumer.java
@@ -523,6 +523,21 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
     }
 
     /**
+     * Assert that the TestObserver/TestSubscriber received only the specified values in the specified order without terminating.
+     * @param values the values expected
+     * @return this;
+     * @since 2.1.4
+     */
+    @SuppressWarnings("unchecked")
+    @Experimental
+    public final U assertValuesOnly(T... values) {
+        return assertSubscribed()
+                .assertValues(values)
+                .assertNoErrors()
+                .assertNotComplete();
+    }
+
+    /**
      * Assert that the TestObserver/TestSubscriber received only the specified values in any order.
      * <p>This helps asserting when the order of the values is not guaranteed, i.e., when merging
      * asynchronous streams.

--- a/src/test/java/io/reactivex/observers/TestObserverTest.java
+++ b/src/test/java/io/reactivex/observers/TestObserverTest.java
@@ -1439,4 +1439,66 @@ public class TestObserverTest {
             assertTrue(ex.toString(), ex.toString().contains("testing with item=2"));
         }
     }
+
+    @Test
+    public void assertValuesOnly() {
+        TestObserver<Integer> to = TestObserver.create();
+        to.onSubscribe(Disposables.empty());
+        to.assertValuesOnly();
+
+        to.onNext(5);
+        to.assertValuesOnly(5);
+
+        to.onNext(-1);
+        to.assertValuesOnly(5, -1);
+    }
+
+    @Test
+    public void assertValuesOnlyThrowsOnUnexpectedValue() {
+        TestObserver<Integer> to = TestObserver.create();
+        to.onSubscribe(Disposables.empty());
+        to.assertValuesOnly();
+
+        to.onNext(5);
+        to.assertValuesOnly(5);
+
+        to.onNext(-1);
+
+        try {
+            to.assertValuesOnly(5);
+            fail();
+        } catch (AssertionError ex) {
+            // expected
+        }
+    }
+
+    @Test
+    public void assertValuesOnlyThrowsWhenCompleted() {
+        TestObserver<Integer> to = TestObserver.create();
+        to.onSubscribe(Disposables.empty());
+
+        to.onComplete();
+
+        try {
+            to.assertValuesOnly();
+            fail();
+        } catch (AssertionError ex) {
+            // expected
+        }
+    }
+
+    @Test
+    public void assertValuesOnlyThrowsWhenErrored() {
+        TestObserver<Integer> to = TestObserver.create();
+        to.onSubscribe(Disposables.empty());
+
+        to.onError(new TestException());
+
+        try {
+            to.assertValuesOnly();
+            fail();
+        } catch (AssertionError ex) {
+            // expected
+        }
+    }
 }

--- a/src/test/java/io/reactivex/subscribers/TestSubscriberTest.java
+++ b/src/test/java/io/reactivex/subscribers/TestSubscriberTest.java
@@ -1997,4 +1997,66 @@ public class TestSubscriberTest {
             ws.run();
         }
     }
+
+    @Test
+    public void assertValuesOnly() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        ts.onSubscribe(new BooleanSubscription());
+        ts.assertValuesOnly();
+
+        ts.onNext(5);
+        ts.assertValuesOnly(5);
+
+        ts.onNext(-1);
+        ts.assertValuesOnly(5, -1);
+    }
+
+    @Test
+    public void assertValuesOnlyThrowsOnUnexpectedValue() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        ts.onSubscribe(new BooleanSubscription());
+        ts.assertValuesOnly();
+
+        ts.onNext(5);
+        ts.assertValuesOnly(5);
+
+        ts.onNext(-1);
+
+        try {
+            ts.assertValuesOnly(5);
+            fail();
+        } catch (AssertionError ex) {
+            // expected
+        }
+    }
+
+    @Test
+    public void assertValuesOnlyThrowsWhenCompleted() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        ts.onSubscribe(new BooleanSubscription());
+
+        ts.onComplete();
+
+        try {
+            ts.assertValuesOnly();
+            fail();
+        } catch (AssertionError ex) {
+            // expected
+        }
+    }
+
+    @Test
+    public void assertValuesOnlyThrowsWhenErrored() {
+        TestSubscriber<Integer> ts = TestSubscriber.create();
+        ts.onSubscribe(new BooleanSubscription());
+
+        ts.onError(new TestException());
+
+        try {
+            ts.assertValuesOnly();
+            fail();
+        } catch (AssertionError ex) {
+            // expected
+        }
+    }
 }


### PR DESCRIPTION
* 2.x: Add assertValuesOnly to BaseTestConsumer.

* Address comments.

Thank you for contributing to RxJava. Before pressing the "Create Pull Request" button, please consider the following points:

  - [ ] Please give a description about what and why you are contributing, even if it's trivial.

  - [ ] Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those.

  - [ ] Please include a reasonable set of unit tests if you contribute new code or change an existing one. If you contribute an operator, (if applicable) please make sure you have tests for working with an `empty`, `just`, `range` of values as well as an `error` source, with and/or without backpressure and see if unsubscription/cancellation propagates correctly.
