### PR TITLE
2.x: fix assertValueSequence reversed error message (#5594)

### DIFF
--- a/src/main/java/io/reactivex/internal/observers/CallbackCompletableObserver.java
+++ b/src/main/java/io/reactivex/internal/observers/CallbackCompletableObserver.java
@@ -20,10 +20,12 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.observers.LambdaConsumerIntrospection;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class CallbackCompletableObserver
-extends AtomicReference<Disposable> implements CompletableObserver, Disposable, Consumer<Throwable> {
+extends AtomicReference<Disposable>
+        implements CompletableObserver, Disposable, Consumer<Throwable>, LambdaConsumerIntrospection {
 
 
     private static final long serialVersionUID = -4361286194466301354L;
@@ -81,5 +83,10 @@ extends AtomicReference<Disposable> implements CompletableObserver, Disposable, 
     @Override
     public boolean isDisposed() {
         return get() == DisposableHelper.DISPOSED;
+    }
+
+    @Override
+    public boolean hasCustomOnError() {
+        return onError != this;
     }
 }

--- a/src/main/java/io/reactivex/internal/observers/ConsumerSingleObserver.java
+++ b/src/main/java/io/reactivex/internal/observers/ConsumerSingleObserver.java
@@ -20,11 +20,13 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.Consumer;
 import io.reactivex.internal.disposables.*;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.observers.LambdaConsumerIntrospection;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class ConsumerSingleObserver<T>
 extends AtomicReference<Disposable>
-implements SingleObserver<T>, Disposable {
+implements SingleObserver<T>, Disposable, LambdaConsumerIntrospection {
 
 
     private static final long serialVersionUID = -7012088219455310787L;
@@ -73,5 +75,10 @@ implements SingleObserver<T>, Disposable {
     @Override
     public boolean isDisposed() {
         return get() == DisposableHelper.DISPOSED;
+    }
+
+    @Override
+    public boolean hasCustomOnError() {
+        return onError != Functions.ON_ERROR_MISSING;
     }
 }

--- a/src/main/java/io/reactivex/internal/observers/EmptyCompletableObserver.java
+++ b/src/main/java/io/reactivex/internal/observers/EmptyCompletableObserver.java
@@ -19,11 +19,12 @@ import io.reactivex.CompletableObserver;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.OnErrorNotImplementedException;
 import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.observers.LambdaConsumerIntrospection;
 import io.reactivex.plugins.RxJavaPlugins;
 
 public final class EmptyCompletableObserver
 extends AtomicReference<Disposable>
-implements CompletableObserver, Disposable {
+implements CompletableObserver, Disposable, LambdaConsumerIntrospection {
 
 
     private static final long serialVersionUID = -7545121636549663526L;
@@ -55,4 +56,8 @@ implements CompletableObserver, Disposable {
         DisposableHelper.setOnce(this, d);
     }
 
+    @Override
+    public boolean hasCustomOnError() {
+        return false;
+    }
 }

--- a/src/main/java/io/reactivex/internal/observers/LambdaObserver.java
+++ b/src/main/java/io/reactivex/internal/observers/LambdaObserver.java
@@ -20,9 +20,12 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.observers.LambdaConsumerIntrospection;
 import io.reactivex.plugins.RxJavaPlugins;
 
-public final class LambdaObserver<T> extends AtomicReference<Disposable> implements Observer<T>, Disposable {
+public final class LambdaObserver<T> extends AtomicReference<Disposable>
+        implements Observer<T>, Disposable, LambdaConsumerIntrospection {
 
     private static final long serialVersionUID = -7251123623727029452L;
     final Consumer<? super T> onNext;
@@ -100,5 +103,10 @@ public final class LambdaObserver<T> extends AtomicReference<Disposable> impleme
     @Override
     public boolean isDisposed() {
         return get() == DisposableHelper.DISPOSED;
+    }
+
+    @Override
+    public boolean hasCustomOnError() {
+        return onError != Functions.ON_ERROR_MISSING;
     }
 }

--- a/src/main/java/io/reactivex/internal/operators/maybe/MaybeCallbackObserver.java
+++ b/src/main/java/io/reactivex/internal/operators/maybe/MaybeCallbackObserver.java
@@ -20,6 +20,8 @@ import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.disposables.DisposableHelper;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.observers.LambdaConsumerIntrospection;
 import io.reactivex.plugins.RxJavaPlugins;
 
 /**
@@ -29,7 +31,7 @@ import io.reactivex.plugins.RxJavaPlugins;
  */
 public final class MaybeCallbackObserver<T>
 extends AtomicReference<Disposable>
-implements MaybeObserver<T>, Disposable {
+implements MaybeObserver<T>, Disposable, LambdaConsumerIntrospection {
 
 
     private static final long serialVersionUID = -6076952298809384986L;
@@ -96,5 +98,8 @@ implements MaybeObserver<T>, Disposable {
         }
     }
 
-
+    @Override
+    public boolean hasCustomOnError() {
+        return onError != Functions.ON_ERROR_MISSING;
+    }
 }

--- a/src/main/java/io/reactivex/internal/subscribers/LambdaSubscriber.java
+++ b/src/main/java/io/reactivex/internal/subscribers/LambdaSubscriber.java
@@ -15,6 +15,8 @@ package io.reactivex.internal.subscribers;
 
 import java.util.concurrent.atomic.AtomicReference;
 
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.observers.LambdaConsumerIntrospection;
 import org.reactivestreams.Subscription;
 
 import io.reactivex.FlowableSubscriber;
@@ -24,7 +26,8 @@ import io.reactivex.functions.*;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.plugins.RxJavaPlugins;
 
-public final class LambdaSubscriber<T> extends AtomicReference<Subscription> implements FlowableSubscriber<T>, Subscription, Disposable {
+public final class LambdaSubscriber<T> extends AtomicReference<Subscription>
+        implements FlowableSubscriber<T>, Subscription, Disposable, LambdaConsumerIntrospection {
 
     private static final long serialVersionUID = -7251123623727029452L;
     final Consumer<? super T> onNext;
@@ -114,5 +117,10 @@ public final class LambdaSubscriber<T> extends AtomicReference<Subscription> imp
     @Override
     public void cancel() {
         SubscriptionHelper.cancel(this);
+    }
+
+    @Override
+    public boolean hasCustomOnError() {
+        return onError != Functions.ON_ERROR_MISSING;
     }
 }

--- a/src/main/java/io/reactivex/observers/BaseTestConsumer.java
+++ b/src/main/java/io/reactivex/observers/BaseTestConsumer.java
@@ -567,20 +567,20 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> impl
     @SuppressWarnings("unchecked")
     public final U assertValueSequence(Iterable<? extends T> sequence) {
         int i = 0;
-        Iterator<T> vit = values.iterator();
-        Iterator<? extends T> it = sequence.iterator();
+        Iterator<T> actualIterator = values.iterator();
+        Iterator<? extends T> expectedIterator = sequence.iterator();
         boolean actualNext;
         boolean expectedNext;
         for (;;) {
-            actualNext = it.hasNext();
-            expectedNext = vit.hasNext();
+            expectedNext = expectedIterator.hasNext();
+            actualNext = actualIterator.hasNext();
 
             if (!actualNext || !expectedNext) {
                 break;
             }
 
-            T v = it.next();
-            T u = vit.next();
+            T u = expectedIterator.next();
+            T v = actualIterator.next();
 
             if (!ObjectHelper.equals(u, v)) {
                 throw fail("Values at position " + i + " differ; Expected: " + valueAndClass(u) + ", Actual: " + valueAndClass(v));

--- a/src/main/java/io/reactivex/observers/LambdaConsumerIntrospection.java
+++ b/src/main/java/io/reactivex/observers/LambdaConsumerIntrospection.java
@@ -1,0 +1,23 @@
+package io.reactivex.observers;
+
+import io.reactivex.annotations.Experimental;
+
+/**
+ * An interface that indicates that the implementing type is composed of individual components and exposes information
+ * about their behavior.
+ *
+ * <p><em>NOTE:</em> This is considered a read-only public API and is not intended to be implemented externally.
+ *
+ * @since 2.1.4 - experimental
+ */
+@Experimental
+public interface LambdaConsumerIntrospection {
+
+    /**
+     * @return {@code true} if a custom onError consumer implementation was supplied. Returns {@code false} if the
+     * implementation is missing an error consumer and thus using a throwing default implementation.
+     */
+    @Experimental
+    boolean hasCustomOnError();
+
+}

--- a/src/test/java/io/reactivex/internal/observers/CallbackCompletableObserverTest.java
+++ b/src/test/java/io/reactivex/internal/observers/CallbackCompletableObserverTest.java
@@ -1,0 +1,25 @@
+package io.reactivex.internal.observers;
+
+import io.reactivex.internal.functions.Functions;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public final class CallbackCompletableObserverTest {
+
+    @Test
+    public void emptyActionShouldReportNoCustomOnError() {
+        CallbackCompletableObserver o = new CallbackCompletableObserver(Functions.EMPTY_ACTION);
+
+        assertFalse(o.hasCustomOnError());
+    }
+
+    @Test
+    public void customOnErrorShouldReportCustomOnError() {
+        CallbackCompletableObserver o = new CallbackCompletableObserver(Functions.<Throwable>emptyConsumer(),
+                Functions.EMPTY_ACTION);
+
+        assertTrue(o.hasCustomOnError());
+    }
+
+}

--- a/src/test/java/io/reactivex/internal/observers/ConsumerSingleObserverTest.java
+++ b/src/test/java/io/reactivex/internal/observers/ConsumerSingleObserverTest.java
@@ -1,0 +1,26 @@
+package io.reactivex.internal.observers;
+
+import io.reactivex.internal.functions.Functions;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public final class ConsumerSingleObserverTest {
+
+    @Test
+    public void onErrorMissingShouldReportNoCustomOnError() {
+        ConsumerSingleObserver<Integer> o = new ConsumerSingleObserver<Integer>(Functions.<Integer>emptyConsumer(),
+                Functions.ON_ERROR_MISSING);
+
+        assertFalse(o.hasCustomOnError());
+    }
+
+    @Test
+    public void customOnErrorShouldReportCustomOnError() {
+        ConsumerSingleObserver<Integer> o = new ConsumerSingleObserver<Integer>(Functions.<Integer>emptyConsumer(),
+                Functions.<Throwable>emptyConsumer());
+
+        assertTrue(o.hasCustomOnError());
+    }
+
+}

--- a/src/test/java/io/reactivex/internal/observers/EmptyCompletableObserverTest.java
+++ b/src/test/java/io/reactivex/internal/observers/EmptyCompletableObserverTest.java
@@ -1,0 +1,15 @@
+package io.reactivex.internal.observers;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+
+public final class EmptyCompletableObserverTest {
+
+    @Test
+    public void defaultShouldReportNoCustomOnError() {
+        EmptyCompletableObserver o = new EmptyCompletableObserver();
+
+        assertFalse(o.hasCustomOnError());
+    }
+}

--- a/src/test/java/io/reactivex/internal/observers/LambdaObserverTest.java
+++ b/src/test/java/io/reactivex/internal/observers/LambdaObserverTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.*;
 
 import java.util.*;
 
+import io.reactivex.internal.functions.Functions;
 import org.junit.Test;
 
 import io.reactivex.Observable;
@@ -341,5 +342,25 @@ public class LambdaObserverTest {
         assertFalse("No errors?!", errors.isEmpty());
 
         assertTrue(errors.toString(), errors.get(0) instanceof TestException);
+    }
+
+    @Test
+    public void onErrorMissingShouldReportNoCustomOnError() {
+        LambdaObserver<Integer> o = new LambdaObserver<Integer>(Functions.<Integer>emptyConsumer(),
+                Functions.ON_ERROR_MISSING,
+                Functions.EMPTY_ACTION,
+                Functions.<Disposable>emptyConsumer());
+
+        assertFalse(o.hasCustomOnError());
+    }
+
+    @Test
+    public void customOnErrorShouldReportCustomOnError() {
+        LambdaObserver<Integer> o = new LambdaObserver<Integer>(Functions.<Integer>emptyConsumer(),
+                Functions.<Throwable>emptyConsumer(),
+                Functions.EMPTY_ACTION,
+                Functions.<Disposable>emptyConsumer());
+
+        assertTrue(o.hasCustomOnError());
     }
 }

--- a/src/test/java/io/reactivex/internal/operators/maybe/MaybeCallbackObserverTest.java
+++ b/src/test/java/io/reactivex/internal/operators/maybe/MaybeCallbackObserverTest.java
@@ -13,18 +13,17 @@
 
 package io.reactivex.internal.operators.maybe;
 
-import static org.junit.Assert.*;
-
-import java.util.List;
-
-import org.junit.Test;
-
 import io.reactivex.TestHelper;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
 import io.reactivex.internal.functions.Functions;
 import io.reactivex.plugins.RxJavaPlugins;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
 
 public class MaybeCallbackObserverTest {
 
@@ -120,5 +119,23 @@ public class MaybeCallbackObserverTest {
         } finally {
             RxJavaPlugins.reset();
         }
+    }
+
+    @Test
+    public void onErrorMissingShouldReportNoCustomOnError() {
+        MaybeCallbackObserver<Integer> o = new MaybeCallbackObserver<Integer>(Functions.<Integer>emptyConsumer(),
+                Functions.ON_ERROR_MISSING,
+                Functions.EMPTY_ACTION);
+
+        assertFalse(o.hasCustomOnError());
+    }
+
+    @Test
+    public void customOnErrorShouldReportCustomOnError() {
+        MaybeCallbackObserver<Integer> o = new MaybeCallbackObserver<Integer>(Functions.<Integer>emptyConsumer(),
+                Functions.<Throwable>emptyConsumer(),
+                Functions.EMPTY_ACTION);
+
+        assertTrue(o.hasCustomOnError());
     }
 }

--- a/src/test/java/io/reactivex/internal/subscribers/LambdaSubscriberTest.java
+++ b/src/test/java/io/reactivex/internal/subscribers/LambdaSubscriberTest.java
@@ -13,19 +13,20 @@
 
 package io.reactivex.internal.subscribers;
 
-import static org.junit.Assert.*;
-
-import java.util.*;
-
-import org.junit.Test;
-import org.reactivestreams.*;
-
 import io.reactivex.*;
 import io.reactivex.exceptions.*;
 import io.reactivex.functions.*;
+import io.reactivex.internal.functions.Functions;
+import io.reactivex.internal.operators.flowable.FlowableInternalHelper;
 import io.reactivex.internal.subscriptions.BooleanSubscription;
 import io.reactivex.plugins.RxJavaPlugins;
 import io.reactivex.processors.PublishProcessor;
+import org.junit.Test;
+import org.reactivestreams.*;
+
+import java.util.*;
+
+import static org.junit.Assert.*;
 
 public class LambdaSubscriberTest {
 
@@ -346,5 +347,25 @@ public class LambdaSubscriberTest {
         assertFalse("No errors?!", errors.isEmpty());
 
         assertTrue(errors.toString(), errors.get(0) instanceof TestException);
+    }
+
+    @Test
+    public void onErrorMissingShouldReportNoCustomOnError() {
+        LambdaSubscriber<Integer> o = new LambdaSubscriber<Integer>(Functions.<Integer>emptyConsumer(),
+                Functions.ON_ERROR_MISSING,
+                Functions.EMPTY_ACTION,
+                FlowableInternalHelper.RequestMax.INSTANCE);
+
+        assertFalse(o.hasCustomOnError());
+    }
+
+    @Test
+    public void customOnErrorShouldReportCustomOnError() {
+        LambdaSubscriber<Integer> o = new LambdaSubscriber<Integer>(Functions.<Integer>emptyConsumer(),
+                Functions.<Throwable>emptyConsumer(),
+                Functions.EMPTY_ACTION,
+                FlowableInternalHelper.RequestMax.INSTANCE);
+
+        assertTrue(o.hasCustomOnError());
     }
 }

--- a/src/test/java/io/reactivex/observers/TestObserverTest.java
+++ b/src/test/java/io/reactivex/observers/TestObserverTest.java
@@ -956,15 +956,15 @@ public class TestObserverTest {
         try {
             ts.assertValueSequence(Collections.<Integer>emptyList());
             throw new RuntimeException("Should have thrown");
-        } catch (AssertionError ex) {
-            // expected
+        } catch (AssertionError expected) {
+            assertTrue(expected.getMessage(), expected.getMessage().startsWith("More values received than expected (0)"));
         }
 
         try {
             ts.assertValueSequence(Collections.singletonList(1));
             throw new RuntimeException("Should have thrown");
-        } catch (AssertionError ex) {
-            // expected
+        } catch (AssertionError expected) {
+            assertTrue(expected.getMessage(), expected.getMessage().startsWith("More values received than expected (1)"));
         }
 
         ts.assertValueSequence(Arrays.asList(1, 2));
@@ -972,8 +972,8 @@ public class TestObserverTest {
         try {
             ts.assertValueSequence(Arrays.asList(1, 2, 3));
             throw new RuntimeException("Should have thrown");
-        } catch (AssertionError ex) {
-            // expected
+        } catch (AssertionError expected) {
+            assertTrue(expected.getMessage(), expected.getMessage().startsWith("Fewer values received than expected (2)"));
         }
     }
 


### PR DESCRIPTION
* 2.x: fix assertValueSequence reversed error message

* Fix variable naming instead

* Adjust according to the feedback

Thank you for contributing to RxJava. Before pressing the "Create Pull Request" button, please consider the following points:

  - [ ] Please give a description about what and why you are contributing, even if it's trivial.

  - [ ] Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those.

  - [ ] Please include a reasonable set of unit tests if you contribute new code or change an existing one. If you contribute an operator, (if applicable) please make sure you have tests for working with an `empty`, `just`, `range` of values as well as an `error` source, with and/or without backpressure and see if unsubscription/cancellation propagates correctly.
