### PR TITLE
2.x: fix incorrect error message at SubscriptionHelper.setOnce (#5623)

### DIFF
--- a/src/main/java/io/reactivex/internal/subscriptions/SubscriptionHelper.java
+++ b/src/main/java/io/reactivex/internal/subscriptions/SubscriptionHelper.java
@@ -137,7 +137,7 @@ public enum SubscriptionHelper implements Subscription {
      * @return true if the operation succeeded, false if the target field was not null.
      */
     public static boolean setOnce(AtomicReference<Subscription> field, Subscription s) {
-        ObjectHelper.requireNonNull(s, "d is null");
+        ObjectHelper.requireNonNull(s, "s is null");
         if (!field.compareAndSet(null, s)) {
             s.cancel();
             if (field.get() != CANCELLED) {


### PR DESCRIPTION
Thank you for contributing to RxJava. Before pressing the "Create Pull Request" button, please consider the following points:

  - [ ] Please give a description about what and why you are contributing, even if it's trivial.

  - [ ] Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those.

  - [ ] Please include a reasonable set of unit tests if you contribute new code or change an existing one. If you contribute an operator, (if applicable) please make sure you have tests for working with an `empty`, `just`, `range` of values as well as an `error` source, with and/or without backpressure and see if unsubscription/cancellation propagates correctly.
