### PR TITLE
Update upstream

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferBoundary.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBufferBoundary.java
@@ -15,22 +15,19 @@ package io.reactivex.internal.operators.flowable;
 
 import java.util.*;
 import java.util.concurrent.Callable;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.*;
 
 import org.reactivestreams.*;
 
-import io.reactivex.Flowable;
+import io.reactivex.*;
 import io.reactivex.disposables.*;
 import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
 import io.reactivex.internal.functions.ObjectHelper;
-import io.reactivex.internal.fuseable.SimplePlainQueue;
-import io.reactivex.internal.queue.MpscLinkedQueue;
-import io.reactivex.internal.subscribers.QueueDrainSubscriber;
+import io.reactivex.internal.queue.SpscLinkedArrayQueue;
 import io.reactivex.internal.subscriptions.SubscriptionHelper;
-import io.reactivex.internal.util.QueueDrainHelper;
+import io.reactivex.internal.util.*;
 import io.reactivex.plugins.RxJavaPlugins;
-import io.reactivex.subscribers.*;
 
 public final class FlowableBufferBoundary<T, U extends Collection<? super T>, Open, Close>
 extends AbstractFlowableWithUpstream<T, U> {
@@ -48,48 +45,72 @@ extends AbstractFlowableWithUpstream<T, U> {
 
     @Override
     protected void subscribeActual(Subscriber<? super U> s) {
-        source.subscribe(new BufferBoundarySubscriber<T, U, Open, Close>(
-                new SerializedSubscriber<U>(s),
-                bufferOpen, bufferClose, bufferSupplier
-            ));
+        BufferBoundarySubscriber<T, U, Open, Close> parent =
+            new BufferBoundarySubscriber<T, U, Open, Close>(
+                s, bufferOpen, bufferClose, bufferSupplier
+            );
+        s.onSubscribe(parent);
+        source.subscribe(parent);
     }
 
-    static final class BufferBoundarySubscriber<T, U extends Collection<? super T>, Open, Close>
-    extends QueueDrainSubscriber<T, U, U> implements Subscription, Disposable {
+    static final class BufferBoundarySubscriber<T, C extends Collection<? super T>, Open, Close>
+    extends AtomicInteger implements FlowableSubscriber<T>, Subscription {
+
+        private static final long serialVersionUID = -8466418554264089604L;
+
+        final Subscriber<? super C> actual;
+
+        final Callable<C> bufferSupplier;
+
         final Publisher<? extends Open> bufferOpen;
+
         final Function<? super Open, ? extends Publisher<? extends Close>> bufferClose;
-        final Callable<U> bufferSupplier;
-        final CompositeDisposable resources;
 
-        Subscription s;
+        final CompositeDisposable subscribers;
 
-        final List<U> buffers;
+        final AtomicLong requested;
 
-        final AtomicInteger windows = new AtomicInteger();
+        final AtomicReference<Subscription> upstream;
 
-        BufferBoundarySubscriber(Subscriber<? super U> actual,
+        final AtomicThrowable errors;
+
+        volatile boolean done;
+
+        final SpscLinkedArrayQueue<C> queue;
+
+        volatile boolean cancelled;
+
+        long index;
+
+        Map<Long, C> buffers;
+
+        long emitted;
+
+        BufferBoundarySubscriber(Subscriber<? super C> actual,
                 Publisher<? extends Open> bufferOpen,
                 Function<? super Open, ? extends Publisher<? extends Close>> bufferClose,
-                        Callable<U> bufferSupplier) {
-            super(actual, new MpscLinkedQueue<U>());
+                Callable<C> bufferSupplier
+        ) {
+            this.actual = actual;
+            this.bufferSupplier = bufferSupplier;
             this.bufferOpen = bufferOpen;
             this.bufferClose = bufferClose;
-            this.bufferSupplier = bufferSupplier;
-            this.buffers = new LinkedList<U>();
-            this.resources = new CompositeDisposable();
+            this.queue = new SpscLinkedArrayQueue<C>(bufferSize());
+            this.subscribers = new CompositeDisposable();
+            this.requested = new AtomicLong();
+            this.upstream = new AtomicReference<Subscription>();
+            this.buffers = new LinkedHashMap<Long, C>();
+            this.errors = new AtomicThrowable();
         }
+
         @Override
         public void onSubscribe(Subscription s) {
-            if (SubscriptionHelper.validate(this.s, s)) {
-                this.s = s;
+            if (SubscriptionHelper.setOnce(this.upstream, s)) {
 
-                BufferOpenSubscriber<T, U, Open, Close> bos = new BufferOpenSubscriber<T, U, Open, Close>(this);
-                resources.add(bos);
+                BufferOpenSubscriber<Open> open = new BufferOpenSubscriber<Open>(this);
+                subscribers.add(open);
 
-                actual.onSubscribe(this);
-
-                windows.lazySet(1);
-                bufferOpen.subscribe(bos);
+                bufferOpen.subscribe(open);
 
                 s.request(Long.MAX_VALUE);
             }
@@ -98,7 +119,11 @@ extends AbstractFlowableWithUpstream<T, U> {
         @Override
         public void onNext(T t) {
             synchronized (this) {
-                for (U b : buffers) {
+                Map<Long, C> bufs = buffers;
+                if (bufs == null) {
+                    return;
+                }
+                for (C b : bufs.values()) {
                     b.add(t);
                 }
             }
@@ -106,206 +131,294 @@ extends AbstractFlowableWithUpstream<T, U> {
 
         @Override
         public void onError(Throwable t) {
-            cancel();
-            cancelled = true;
-            synchronized (this) {
-                buffers.clear();
+            if (errors.addThrowable(t)) {
+                subscribers.dispose();
+                synchronized (this) {
+                    buffers = null;
+                }
+                done = true;
+                drain();
+            } else {
+                RxJavaPlugins.onError(t);
             }
-            actual.onError(t);
         }
 
         @Override
         public void onComplete() {
-            if (windows.decrementAndGet() == 0) {
-                complete();
-            }
-        }
-
-        void complete() {
-            List<U> list;
+            subscribers.dispose();
             synchronized (this) {
-                list = new ArrayList<U>(buffers);
-                buffers.clear();
-            }
-
-            SimplePlainQueue<U> q = queue;
-            for (U u : list) {
-                q.offer(u);
+                Map<Long, C> bufs = buffers;
+                if (bufs == null) {
+                    return;
+                }
+                for (C b : bufs.values()) {
+                    queue.offer(b);
+                }
+                buffers = null;
             }
             done = true;
-            if (enter()) {
-                QueueDrainHelper.drainMaxLoop(q, actual, false, this, this);
-            }
+            drain();
         }
 
         @Override
         public void request(long n) {
-            requested(n);
-        }
-
-        @Override
-        public void dispose() {
-            resources.dispose();
-        }
-
-        @Override
-        public boolean isDisposed() {
-            return resources.isDisposed();
+            BackpressureHelper.add(requested, n);
+            drain();
         }
 
         @Override
         public void cancel() {
-            if (!cancelled) {
+            if (SubscriptionHelper.cancel(upstream)) {
                 cancelled = true;
-                dispose();
+                subscribers.dispose();
+                synchronized (this) {
+                    buffers = null;
+                }
+                if (getAndIncrement() != 0) {
+                    queue.clear();
+                }
             }
         }
 
-        @Override
-        public boolean accept(Subscriber<? super U> a, U v) {
-            a.onNext(v);
-            return true;
-        }
-
-        void open(Open window) {
-            if (cancelled) {
-                return;
-            }
-
-            U b;
-
-            try {
-                b = ObjectHelper.requireNonNull(bufferSupplier.call(), "The buffer supplied is null");
-            } catch (Throwable e) {
-                Exceptions.throwIfFatal(e);
-                onError(e);
-                return;
-            }
-
+        void open(Open token) {
             Publisher<? extends Close> p;
-
+            C buf;
             try {
-                p = ObjectHelper.requireNonNull(bufferClose.apply(window), "The buffer closing publisher is null");
-            } catch (Throwable e) {
-                Exceptions.throwIfFatal(e);
-                onError(e);
+                buf = ObjectHelper.requireNonNull(bufferSupplier.call(), "The bufferSupplier returned a null Collection");
+                p = ObjectHelper.requireNonNull(bufferClose.apply(token), "The bufferClose returned a null Publisher");
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                SubscriptionHelper.cancel(upstream);
+                onError(ex);
                 return;
             }
 
-            if (cancelled) {
-                return;
-            }
-
+            long idx = index;
+            index = idx + 1;
             synchronized (this) {
-                if (cancelled) {
+                Map<Long, C> bufs = buffers;
+                if (bufs == null) {
                     return;
                 }
-                buffers.add(b);
+                bufs.put(idx, buf);
             }
 
-            BufferCloseSubscriber<T, U, Open, Close> bcs = new BufferCloseSubscriber<T, U, Open, Close>(b, this);
-            resources.add(bcs);
-
-            windows.getAndIncrement();
-
-            p.subscribe(bcs);
+            BufferCloseSubscriber<T, C> bc = new BufferCloseSubscriber<T, C>(this, idx);
+            subscribers.add(bc);
+            p.subscribe(bc);
         }
 
-        void openFinished(Disposable d) {
-            if (resources.remove(d)) {
-                if (windows.decrementAndGet() == 0) {
-                    complete();
-                }
+        void openComplete(BufferOpenSubscriber<Open> os) {
+            subscribers.delete(os);
+            if (subscribers.size() == 0) {
+                SubscriptionHelper.cancel(upstream);
+                done = true;
+                drain();
             }
         }
 
-        void close(U b, Disposable d) {
-
-            boolean e;
+        void close(BufferCloseSubscriber<T, C> closer, long idx) {
+            subscribers.delete(closer);
+            boolean makeDone = false;
+            if (subscribers.size() == 0) {
+                makeDone = true;
+                SubscriptionHelper.cancel(upstream);
+            }
             synchronized (this) {
-                e = buffers.remove(b);
+                Map<Long, C> bufs = buffers;
+                if (bufs == null) {
+                    return;
+                }
+                queue.offer(buffers.remove(idx));
+            }
+            if (makeDone) {
+                done = true;
+            }
+            drain();
+        }
+
+        void boundaryError(Disposable subscriber, Throwable ex) {
+            SubscriptionHelper.cancel(upstream);
+            subscribers.delete(subscriber);
+            onError(ex);
+        }
+
+        void drain() {
+            if (getAndIncrement() != 0) {
+                return;
             }
 
-            if (e) {
-                fastPathOrderedEmitMax(b, false, this);
-            }
+            int missed = 1;
+            long e = emitted;
+            Subscriber<? super C> a = actual;
+            SpscLinkedArrayQueue<C> q = queue;
 
-            if (resources.remove(d)) {
-                if (windows.decrementAndGet() == 0) {
-                    complete();
+            for (;;) {
+                long r = requested.get();
+
+                while (e != r) {
+                    if (cancelled) {
+                        q.clear();
+                        return;
+                    }
+
+                    boolean d = done;
+                    if (d && errors.get() != null) {
+                        q.clear();
+                        Throwable ex = errors.terminate();
+                        a.onError(ex);
+                        return;
+                    }
+
+                    C v = q.poll();
+                    boolean empty = v == null;
+
+                    if (d && empty) {
+                        a.onComplete();
+                        return;
+                    }
+
+                    if (empty) {
+                        break;
+                    }
+
+                    a.onNext(v);
+                    e++;
+                }
+
+                if (e == r) {
+                    if (cancelled) {
+                        q.clear();
+                        return;
+                    }
+
+                    if (done) {
+                        if (errors.get() != null) {
+                            q.clear();
+                            Throwable ex = errors.terminate();
+                            a.onError(ex);
+                            return;
+                        } else if (q.isEmpty()) {
+                            a.onComplete();
+                            return;
+                        }
+                    }
+                }
+
+                emitted = e;
+                missed = addAndGet(-missed);
+                if (missed == 0) {
+                    break;
                 }
             }
         }
+
+        static final class BufferOpenSubscriber<Open>
+        extends AtomicReference<Subscription>
+        implements FlowableSubscriber<Open>, Disposable {
+
+            private static final long serialVersionUID = -8498650778633225126L;
+
+            final BufferBoundarySubscriber<?, ?, Open, ?> parent;
+
+            BufferOpenSubscriber(BufferBoundarySubscriber<?, ?, Open, ?> parent) {
+                this.parent = parent;
+            }
+
+            @Override
+            public void onSubscribe(Subscription s) {
+                if (SubscriptionHelper.setOnce(this, s)) {
+                    s.request(Long.MAX_VALUE);
+                }
+            }
+
+            @Override
+            public void onNext(Open t) {
+                parent.open(t);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                lazySet(SubscriptionHelper.CANCELLED);
+                parent.boundaryError(this, t);
+            }
+
+            @Override
+            public void onComplete() {
+                lazySet(SubscriptionHelper.CANCELLED);
+                parent.openComplete(this);
+            }
+
+            @Override
+            public void dispose() {
+                SubscriptionHelper.cancel(this);
+            }
+
+            @Override
+            public boolean isDisposed() {
+                return get() == SubscriptionHelper.CANCELLED;
+            }
+        }
     }
 
-    static final class BufferOpenSubscriber<T, U extends Collection<? super T>, Open, Close>
-    extends DisposableSubscriber<Open> {
-        final BufferBoundarySubscriber<T, U, Open, Close> parent;
+    static final class BufferCloseSubscriber<T, C extends Collection<? super T>>
+    extends AtomicReference<Subscription>
+    implements FlowableSubscriber<Object>, Disposable {
 
-        boolean done;
+        private static final long serialVersionUID = -8498650778633225126L;
 
-        BufferOpenSubscriber(BufferBoundarySubscriber<T, U, Open, Close> parent) {
+        final BufferBoundarySubscriber<T, C, ?, ?> parent;
+
+        final long index;
+
+        BufferCloseSubscriber(BufferBoundarySubscriber<T, C, ?, ?> parent, long index) {
             this.parent = parent;
+            this.index = index;
         }
+
         @Override
-        public void onNext(Open t) {
-            if (done) {
-                return;
+        public void onSubscribe(Subscription s) {
+            if (SubscriptionHelper.setOnce(this, s)) {
+                s.request(Long.MAX_VALUE);
             }
-            parent.open(t);
+        }
+
+        @Override
+        public void onNext(Object t) {
+            Subscription s = get();
+            if (s != SubscriptionHelper.CANCELLED) {
+                lazySet(SubscriptionHelper.CANCELLED);
+                s.cancel();
+                parent.close(this, index);
+            }
         }
 
         @Override
         public void onError(Throwable t) {
-            if (done) {
+            if (get() != SubscriptionHelper.CANCELLED) {
+                lazySet(SubscriptionHelper.CANCELLED);
+                parent.boundaryError(this, t);
+            } else {
                 RxJavaPlugins.onError(t);
-                return;
             }
-            done = true;
-            parent.onError(t);
         }
 
         @Override
         public void onComplete() {
-            if (done) {
-                return;
+            if (get() != SubscriptionHelper.CANCELLED) {
+                lazySet(SubscriptionHelper.CANCELLED);
+                parent.close(this, index);
             }
-            done = true;
-            parent.openFinished(this);
-        }
-    }
-
-    static final class BufferCloseSubscriber<T, U extends Collection<? super T>, Open, Close>
-    extends DisposableSubscriber<Close> {
-        final BufferBoundarySubscriber<T, U, Open, Close> parent;
-        final U value;
-        boolean done;
-        BufferCloseSubscriber(U value, BufferBoundarySubscriber<T, U, Open, Close> parent) {
-            this.parent = parent;
-            this.value = value;
         }
 
         @Override
-        public void onNext(Close t) {
-            onComplete();
+        public void dispose() {
+            SubscriptionHelper.cancel(this);
         }
 
         @Override
-        public void onError(Throwable t) {
-            if (done) {
-                RxJavaPlugins.onError(t);
-                return;
-            }
-            parent.onError(t);
-        }
-
-        @Override
-        public void onComplete() {
-            if (done) {
-                return;
-            }
-            done = true;
-            parent.close(value, this);
+        public boolean isDisposed() {
+            return get() == SubscriptionHelper.CANCELLED;
         }
     }
 }


### PR DESCRIPTION
* 2.x: Fix buffer(open, close) not disposing indicators properly

* Unify boundary error methods, fix cleanup, fix last buffer orders

* Fix nits.

Thank you for contributing to RxJava. Before pressing the "Create Pull Request" button, please consider the following points:

  - [ ] Please give a description about what and why you are contributing, even if it's trivial.

  - [ ] Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those.

  - [ ] Please include a reasonable set of unit tests if you contribute new code or change an existing one. If you contribute an operator, (if applicable) please make sure you have tests for working with an `empty`, `just`, `range` of values as well as an `error` source, with and/or without backpressure and see if unsubscription/cancellation propagates correctly.
