### PR TITLE
Update upstream

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/observable/ObservableSwitchMap.java
+++ b/src/main/java/io/reactivex/internal/operators/observable/ObservableSwitchMap.java
@@ -131,15 +131,15 @@ public final class ObservableSwitchMap<T, R> extends AbstractObservableWithUpstr
 
         @Override
         public void onError(Throwable t) {
-            if (done || !errors.addThrowable(t)) {
+            if (!done && errors.addThrowable(t)) {
                 if (!delayErrors) {
                     disposeInner();
                 }
+                done = true;
+                drain();
+            } else {
                 RxJavaPlugins.onError(t);
-                return;
             }
-            done = true;
-            drain();
         }
 
         @Override

--- a/src/test/java/io/reactivex/internal/operators/flowable/FlowableSwitchTest.java
+++ b/src/test/java/io/reactivex/internal/operators/flowable/FlowableSwitchTest.java
@@ -1153,4 +1153,25 @@ public class FlowableSwitchTest {
         .test()
         .assertFailure(TestException.class);
     }
+
+    @Test
+    public void innerCancelledOnMainError() {
+        final PublishProcessor<Integer> main = PublishProcessor.create();
+        final PublishProcessor<Integer> inner = PublishProcessor.create();
+
+        TestSubscriber<Integer> to = main.switchMap(Functions.justFunction(inner))
+        .test();
+
+        assertTrue(main.hasSubscribers());
+
+        main.onNext(1);
+
+        assertTrue(inner.hasSubscribers());
+
+        main.onError(new TestException());
+
+        assertFalse(inner.hasSubscribers());
+
+        to.assertFailure(TestException.class);
+    }
 }


### PR DESCRIPTION
…inner source (#5833)

* 2.x: Fix Obs.switchMap main onError not disposing the current inner src

* Fix error-error race test

Thank you for contributing to RxJava. Before pressing the "Create Pull Request" button, please consider the following points:

  - [ ] Please give a description about what and why you are contributing, even if it's trivial.

  - [ ] Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those.

  - [ ] Please include a reasonable set of unit tests if you contribute new code or change an existing one. If you contribute an operator, (if applicable) please make sure you have tests for working with an `empty`, `just`, `range` of values as well as an `error` source, with and/or without backpressure and see if unsubscription/cancellation propagates correctly.
