### PR TITLE
Update upstream

### DIFF
--- a/src/main/java/io/reactivex/internal/operators/flowable/FlowableBlockingSubscribe.java
+++ b/src/main/java/io/reactivex/internal/operators/flowable/FlowableBlockingSubscribe.java
@@ -63,7 +63,7 @@ public final class FlowableBlockingSubscribe {
                 if (bs.isCancelled()) {
                     break;
                 }
-                if (o == BlockingSubscriber.TERMINATED
+                if (v == BlockingSubscriber.TERMINATED
                         || NotificationLite.acceptFull(v, subscriber)) {
                     break;
                 }


### PR DESCRIPTION
Checking `BlockingSubscriber.TERMINATED` (`new Object()`) against `o` would always be false since `o` is a publisher. Since `v` comes from the queue this is presumably the variable that should be checked.

However the check might even be redundant with this change since that variable can only appear in the queue after the subscriber has been cancelled. I am not familiar enough with the memory model to say whether the object appearing in the queue implies the cancelled subscriber is visible.

Thank you for contributing to RxJava. Before pressing the "Create Pull Request" button, please consider the following points:

  - [ ] Please give a description about what and why you are contributing, even if it's trivial.

  - [ ] Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those.

  - [ ] Please include a reasonable set of unit tests if you contribute new code or change an existing one. If you contribute an operator, (if applicable) please make sure you have tests for working with an `empty`, `just`, `range` of values as well as an `error` source, with and/or without backpressure and see if unsubscription/cancellation propagates correctly.
