### PR TITLE
Add NotReady taint to new nodes during admission

### DIFF
--- a/src/main/java/io/reactivex/exceptions/CompositeException.java
+++ b/src/main/java/io/reactivex/exceptions/CompositeException.java
@@ -280,7 +280,7 @@ public final class CompositeException extends RuntimeException {
      */
     /*private */Throwable getRootCause(Throwable e) {
         Throwable root = e.getCause();
-        if (root == null || cause == root) {
+        if (root == null || e == root) {
             return e;
         }
         while (true) {

--- a/src/test/java/io/reactivex/exceptions/CompositeExceptionTest.java
+++ b/src/test/java/io/reactivex/exceptions/CompositeExceptionTest.java
@@ -364,7 +364,22 @@ public class CompositeExceptionTest {
             }
         };
         CompositeException ex = new CompositeException(throwable);
-        assertSame(ex, ex.getRootCause(ex));
+        assertSame(ex0, ex.getRootCause(ex));
+    }
+
+    @Test
+    public void rootCauseSelf() {
+        Throwable throwable = new Throwable() {
+
+            private static final long serialVersionUID = -4398003222998914415L;
+
+            @Override
+            public synchronized Throwable getCause() {
+                return this;
+            }
+        };
+        CompositeException tmp = new CompositeException(new TestException());
+        assertSame(throwable, tmp.getRootCause(throwable));
     }
 }
 


### PR DESCRIPTION
* Fix bug in CompositeException.getRootCause 

The original code use to be `if (root == null || root == e)`, but apparently after some refactoring it ended up as `if (root == null || cause == root)`, which I believe is a bug.

This method should probably be `static` (that would have prevented the bug).

* Update unit tests for CompositeException.getRootCause

Thank you for contributing to RxJava. Before pressing the "Create Pull Request" button, please consider the following points:

  - [ ] Please give a description about what and why you are contributing, even if it's trivial.

  - [ ] Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those.

  - [ ] Please include a reasonable set of unit tests if you contribute new code or change an existing one. If you contribute an operator, (if applicable) please make sure you have tests for working with an `empty`, `just`, `range` of values as well as an `error` source, with and/or without backpressure and see if unsubscription/cancellation propagates correctly.
